### PR TITLE
refactor to work with the new syntax system

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The tool can be run as `npd <cmd>`. where currently we support cmd `validate`:
 In this mode the command has exit code 1 if no hook of any type is found, or any package failed 
 to be validated.
 
-`-p|--packages [PACKAGES [PACKAGES ...]]`: validation runs on packages, it checks packages with 
+`-p|--packages [PACKAGES [PACKAGES ...]]`: validation runs on packages built, for example
+`python setup.py sdist bdist_wheel`, it checks packages with 
 given paths, and if no path is given, it runs on all files under `dist` folder to checks that 
 all packages built are correctly tagged with classifier "Framework :: napari". This is 
 recommended for most plugins unless you do not want your plugin to appear in the napari built-in 

--- a/README.md
+++ b/README.md
@@ -25,21 +25,23 @@ The CLI can be used by continuous integration (CI) pipelines to perform a
 quick verification of a plugins setup without any specific input required. 
 It serves as a quick "sanity check". (It is also accessible from python in validation.py)
 
-The tool can be run as `npd <cmd>`. There are 2 commands currently:
+The tool can be run as `npd <cmd>`. where currently we support cmd `validate`:
 
-`npd --validate-packages` should be used after packages are built
-for pypi releases, (example: this repo is built by pep517 standard
-`pip install pep517 && python -m pep517.build .`).  The validator
-checks that all packages built under dist are correctly tagged with
-classifier "Framework :: napari". This is recommended for most plugins
-unless you do not want your plugin to appear in the napari built-in plugin installation tool.
+`-a|--all`: validation is then run on everything, including package checks and all hooks checks.
+In this mode the command has exit code 1 if no hook of any type is found, or any package failed 
+to be validated.
 
-`npd --validate-readers|--validate-writers|--validate-functions|--validate-widgets`, 
-verifies that after the plugin is installed to current python environment, typically done 
-through `pip install -e .`, there is at least one hook under corresponding category 
-registered by the plugin, and there are no conflicts in name or registration error, 
-it also output all registered function signatures in a json format that can be used 
-for further inspection, for example:
+`-p|--packages [PACKAGES [PACKAGES ...]]`: validation runs on packages, it checks packages with 
+given paths, and if no path is given, it runs on all files under `dist` folder to checks that 
+all packages built are correctly tagged with classifier "Framework :: napari". This is 
+recommended for most plugins unless you do not want your plugin to appear in the napari built-in 
+plugin installation tool. Can be used with `-s|--skip-repackaging` when not rebuilding dist folder.
+
+`-k|--hooks {reader,writer,function,widget} [{reader,writer,function,widget} ...]` validation runs on
+provided list of hook types that after the plugin is installed to current python environment, 
+typically done through `pip install -e .`, there is at least one hook under corresponding category 
+registered by the plugin, and there are no conflicts in name or registration error, when used
+with verbose mode, the function signatures are also printed, for example:
 ```
     [{
         "plugin name": "napari-demo",
@@ -55,8 +57,20 @@ for further inspection, for example:
     }]
 ``` 
 
-Multiple cmds in one execution is supported, for example: 
-`npd --validate-readers --validate-functions --validate-packages`
+`-i|--include-plugin INCLUDE_PLUGIN [INCLUDE_PLUGIN ...]` run hook checks only on listed plugins, 
+this is useful to filter out other plugins on a complicated python environment.
+
+
+`-e|--exclude-plugin EXCLUDE_PLUGIN [EXCLUDE_PLUGIN ...]` do not run hook checks on listed plugins, 
+this is useful to filter out other plugins on a complicated python environment.
+
+`-s|--skip-repackaging` when specified, skipping the packaging step before package checks.
+This is useful when the dist folder has correct packages to validate. Otherwise we would rebuild dist
+folder to make sure the result is correctly reflecting latest code status.
+
+`-v|--verbose` enable verbose mode, gives slightly more information on the underlying findings of validation process.
+
+
 
 ### Pytest fixture usage
 devtools provides a pytest fixture: napari_plugin_tester 

--- a/napari_plugin_devtools/__init__.py
+++ b/napari_plugin_devtools/__init__.py
@@ -1,5 +1,5 @@
 __all__ = [
-    "validate_packages",
+    "validate_package",
     "validate_function",
     "list_hook_implementations",
 ]
@@ -7,5 +7,5 @@ __all__ = [
 from .validation import (
     list_hook_implementations,
     validate_function,
-    validate_packages,
+    validate_package,
 )

--- a/napari_plugin_devtools/__main__.py
+++ b/napari_plugin_devtools/__main__.py
@@ -2,73 +2,146 @@
 napari plugin command line developer tool.
 """
 import argparse
+import json
+import os
 import sys
 
-from .validation import Options, list_hook_implementations, validate_packages
-
-print_help = True
+from .validation import Options, list_hook_implementations, validate_package
 
 
 def main():
-    global print_help
-
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '--validate-packages',
+    sub_parsers = parser.add_subparsers(help='validate plugins')
+    validate_parser = sub_parsers.add_parser("validate")
+    validate_parser.add_argument(
+        "-a",
+        "--all",
         action="store_true",
-        help='validate the build packages is marked as napari plugin',
+        help="validate all package and hooks",
     )
-    parser.add_argument(
-        '--validate-readers',
+    validate_parser.add_argument(
+        "-p",
+        "--packages",
+        nargs="*",
+        help="validate specific package or dist folder",
+    )
+    validate_parser.add_argument(
+        "-k",
+        "--hooks",
+        nargs="+",
+        choices=[option.name for option in Options],
+        help="only validate given hooks",
+    )
+    validate_parser.add_argument(
+        "-i",
+        "--include-plugin",
+        nargs="+",
+        help="only include specified plugins",
+    )
+    validate_parser.add_argument(
+        "-e", "--exclude-plugin", nargs="+", help="exclude specified plugins"
+    )
+    validate_parser.add_argument(
+        "-s",
+        "--skip-repackaging",
         action="store_true",
-        help='validate there is a reader hook implemented',
+        help="skip repackaging in package validation",
     )
-    parser.add_argument(
-        '--validate-writers',
-        action="store_true",
-        help='validate there is a writer hook implemented',
+    validate_parser.add_argument(
+        "-v", "--verbose", action="store_true", help="print verbose report"
     )
-    parser.add_argument(
-        '--validate-functions',
-        action="store_true",
-        help='validate there is a function hook implemented',
-    )
-    parser.add_argument(
-        '--validate-widgets',
-        action="store_true",
-        help='validate there is a widget hook implemented',
-    )
+    if len(sys.argv) == 1:
+        parser.print_help()
+        parser.exit()
     args = parser.parse_args()
 
-    err_code = 0
-    if args.validate_packages:
-        err_code += validate_packages('dist')
-        print_help = False
+    packages_validated = True
+    hooks_validated = True
 
-    if args.validate_readers:
-        err_code += validate_hook(Options.reader)
+    if not args.all and args.packages is None and args.hooks is None:
+        validate_parser.print_help()
 
-    if args.validate_writers:
-        err_code += validate_hook(Options.writer)
+    if args.all:
+        args.hooks = ['reader', 'writer', 'function', 'widget']
+        args.packages = []
 
-    if args.validate_functions:
-        err_code += validate_hook(Options.function)
+    if args.packages is not None:
+        packages_validated = validate_packages(args)
 
-    if args.validate_widgets:
-        err_code += validate_hook(Options.widget)
+    if args.hooks:
+        hooks_validated = validate_hooks(args)
 
-    if print_help:
-        parser.print_help()
-    return err_code
+    if packages_validated and hooks_validated:
+        return 0
+    elif packages_validated and not hooks_validated:
+        return 1
+    elif not packages_validated and hooks_validated:
+        return 2
+    else:
+        return 3
 
 
-def validate_hook(option):
-    global print_help
+def validate_hooks(args):
+    errors = []
+    hooks_valid = True
+    for option in Options:
+        if option.name in args.hooks:
+            hook_found, hook_valid = validate_hook(
+                option, args.verbose, args.include_plugin, args.exclude_plugin
+            )
+            if not hook_found:
+                errors.append(option)
+                hooks_valid = hooks_valid and hook_valid
+    if (args.all and len(errors) == len(Options)) or (
+        not args.all and len(errors) > 0
+    ):
+        hooks_valid = False
+        names = json.dumps(
+            {
+                option.name: [hook_caller.name for hook_caller in option.value]
+                for option in errors
+            },
+            default=str,
+            indent=4,
+        )
+        print(
+            f'No hook found for {args.hooks}, please check the following:\n'
+            f'1. Plugin module is registered in entry_points of the project\n'
+            f'2. Plugin hook is annotated with @napari_hook_implementation\n'
+            f'3. The annotated method are named accordingly: {names}'
+        )
 
-    err_code, signature = list_hook_implementations(option)
-    print(f'{option.name}: {signature}')
-    print_help = False
-    return err_code
+    return hooks_valid
+
+
+def validate_packages(args):
+    packages_validated = True
+    if len(args.packages) == 0:
+        for pkgpath in os.listdir("dist"):
+            pkgpath = os.path.join("dist", pkgpath)
+            args.packages.append(pkgpath)
+    for package in args.packages:
+        package_validated = validate_package(package, verbose=args.verbose)
+        if package_validated and args.verbose:
+            print(f'validated {package}')
+        packages_validated = packages_validated and package_validated
+    if packages_validated:
+        print(f"Success! All {len(args.packages)} packages are validated")
+    return packages_validated
+
+
+def validate_hook(option, verbose, include_plugins, exclude_plugins):
+    validated, signatures = list_hook_implementations(
+        option, include_plugins, exclude_plugins
+    )
+    if len(signatures) == 0:
+        return False, validated
+    else:
+        print(f'Found {len(signatures)} {option.name} hooks')
+        if verbose:
+            signature = json.dumps(signatures, default=str, indent=4)
+            print(f'{option.name}: {signature}')
+        return True, validated
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
refactored to use new syntax suggested
support a high level check: npd validate -all
closes #9 
closes #11 