### PR TITLE
address comments on the general usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,20 @@ It serves as a quick "sanity check". (It is also accessible from python in valid
 
 The tool can be run as `npd <cmd>`. where currently we support cmd `validate`:
 
-`npd validate`: list function hooks under current python environment, to install plugin from a repo to python 
+Before running `npd validate`, make sure you have prepared the repo for validation:
+1. install the plugin to the same python environment where `npd validate` is run:
+   ```
+   cd <plugin path>
+   pip install napari-plugin-devtools
+   pip install -e .
+   ```
+2. package the plugin, if skipped we do not run classifier validation, which may cause your plugin not showing 
+   up in napari's plugin installation menu. The build process can be different for your plugin, for a typical setup try:
+   ```
+   python setup.py sdist bdist_wheel
+   ```
+
+`npd validate` list function hooks under current python environment, to install plugin from a repo to python 
 environment, run `pip install -e <plugin path>`
 
 `npd validate -d|--dist dist` name of the dist, default to first plugin name if not provided, should be provided when 

--- a/README.md
+++ b/README.md
@@ -27,20 +27,22 @@ It serves as a quick "sanity check". (It is also accessible from python in valid
 
 The tool can be run as `npd <cmd>`. where currently we support cmd `validate`:
 
-`npd validate`: validate classifiers and function hooks can be recognized by napari.
-The validation would run on built packages under dist folder to check if they are annotated
-properly with framework classifier, and validate hooks are properly annotated that they can be found
-by napari.
+`npd validate`: list function hooks under current python environment, to install plugin from a repo to python 
+environment, run `pip install -e <plugin path>`
 
-`npd validate -i|--include-plugin INCLUDE_PLUGIN [INCLUDE_PLUGIN ...]` run hook checks only on listed plugins, 
-this is useful to filter out other plugins on a complicated python environment.
-
-
-`npd validate -e|--exclude-plugin EXCLUDE_PLUGIN [EXCLUDE_PLUGIN ...]` do not run hook checks on listed plugins, 
-this is useful to filter out other plugins on a complicated python environment.
+`npd validate -d|--dist dist` name of the dist, default to first plugin name if not provided, should be provided when 
+there are multiple plugins in same package or plugin name is different from package name
 
 `npd validate -v|--verbose` enable verbose mode, gives slightly more information on the underlying 
-findings of validation process.
+findings of validation process. By default disabled to avoid the eye sore from too much text.
+
+Output from `npd validate` has multiple sections, where each section is a separate validation where the header
+specifies what is being checked, and the last section is the aggregated report of overall status.
+
+1. Hooks validation: check if there are at least one hook implemented by the plugin.
+2. Builds validation: check if all builds have correct trove classifiers.
+3. Entrypoint validation: check if the specified plugin module is registered as napari plugin in entrypoint.
+4. Validation report: if any of the validation is marked as FAILED, see above sections for details
 
 
 

--- a/README.md
+++ b/README.md
@@ -21,42 +21,8 @@ There are two parts to the validation tool. One part is a
 command line interface, and the other is a pytest fixture.
 
 ### Command Line Interface (CLI) Usage
-The CLI can be used by continuous integration (CI) pipelines to perform a 
-quick verification of a plugin setup without any specific input required. 
-It serves as a quick "sanity check". (It is also accessible via Python in validation.py)
 
-The tool can be run as `npd <cmd>`. where currently we support cmd `validate`:
-
-Before running `npd validate`, make sure you have prepared the repo for validation:
-1. install the plugin to the same python environment where `npd validate` is run:
-   ```
-   cd <plugin path>
-   pip install napari-plugin-devtools
-   pip install -e .
-   ```
-2. package the plugin, if skipped we do not run classifier validation, which may cause your plugin not showing up in 
-   napari native plugin installation menu. The build process can be different for your plugin, for a typical setup try:
-   ```
-   python setup.py sdist bdist_wheel
-   ```
-
-`npd validate` list function hooks under current python environment, to install a plugin from a repo to python 
-environment, run `pip install -e <plugin path>`
-
-`npd validate -d|--dist dist` name of the dist, default to first plugin name if not provided, should be provided when 
-there are multiple plugins in same package or plugin name is different from package name
-
-`npd validate -v|--verbose` enable the verbose mode, gives slightly more information on the underlying 
-findings of validation process. It is by default disabled to avoid the eyesore from too much text.
-
-Output from `npd validate` has multiple sections, where each section is a separate validation where the header
-specifies what is being checked, and the last section is the aggregated report of overall status.
-
-1. Hooks validation: check if there are at least one hook implemented by the plugin.
-2. Builds validation: check if all builds have correct trove classifiers.
-3. Entrypoint validation: check if the specified plugin module is registered as napari plugin in entrypoint.
-4. Validation report: if any of the validation is marked as FAILED, see above sections for details
-
+see [CLI_usage.md](documentation/CLI_usage.md)
 
 
 ### Pytest fixture usage

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ these checks verify that the plugin is available for users of napari
 to install, and would register entry points with napari. 
 
 There are two parts to the validation tool. One part is a 
-command line interface and the other is a pytest fixture.
+command line interface, and the other is a pytest fixture.
 
 ### Command Line Interface (CLI) Usage
 The CLI can be used by continuous integration (CI) pipelines to perform a 
-quick verification of a plugins setup without any specific input required. 
-It serves as a quick "sanity check". (It is also accessible from python in validation.py)
+quick verification of a plugin setup without any specific input required. 
+It serves as a quick "sanity check". (It is also accessible via Python in validation.py)
 
 The tool can be run as `npd <cmd>`. where currently we support cmd `validate`:
 
@@ -34,20 +34,20 @@ Before running `npd validate`, make sure you have prepared the repo for validati
    pip install napari-plugin-devtools
    pip install -e .
    ```
-2. package the plugin, if skipped we do not run classifier validation, which may cause your plugin not showing 
-   up in napari's plugin installation menu. The build process can be different for your plugin, for a typical setup try:
+2. package the plugin, if skipped we do not run classifier validation, which may cause your plugin not showing up in 
+   napari native plugin installation menu. The build process can be different for your plugin, for a typical setup try:
    ```
    python setup.py sdist bdist_wheel
    ```
 
-`npd validate` list function hooks under current python environment, to install plugin from a repo to python 
+`npd validate` list function hooks under current python environment, to install a plugin from a repo to python 
 environment, run `pip install -e <plugin path>`
 
 `npd validate -d|--dist dist` name of the dist, default to first plugin name if not provided, should be provided when 
 there are multiple plugins in same package or plugin name is different from package name
 
-`npd validate -v|--verbose` enable verbose mode, gives slightly more information on the underlying 
-findings of validation process. By default disabled to avoid the eye sore from too much text.
+`npd validate -v|--verbose` enable the verbose mode, gives slightly more information on the underlying 
+findings of validation process. It is by default disabled to avoid the eyesore from too much text.
 
 Output from `npd validate` has multiple sections, where each section is a separate validation where the header
 specifies what is being checked, and the last section is the aggregated report of overall status.
@@ -61,7 +61,7 @@ specifies what is being checked, and the last section is the aggregated report o
 
 ### Pytest fixture usage
 devtools provides a pytest fixture: napari_plugin_tester 
-in plugin_tester.py, it extends a plugin manager used by napari
+in the plugin_tester.py, it extends a plugin manager used by napari
 and have additional assertion modes ready:
 ```
 def test_pm(napari_plugin_tester):

--- a/documentation/CLI_usage.md
+++ b/documentation/CLI_usage.md
@@ -1,0 +1,195 @@
+# CLI Usage
+
+---
+## npd
+
+### Description
+napari plugin devtools scans the current python environment to find out details about napari plugin information.
+
+### Usage
+```
+npd [COMMANDS] [ARGS...]
+```
+
+### Commands
+|Command        |Description                                          |
+|---------------|-----------------------------------------------------|
+|validate       |validate the given package is correctly setup        |
+|discover       |discover all plugins under current python environment|
+
+
+## npd validate
+
+### Description
+Validate package(s) within current python environment, report PASSED or FAILED for each check, 
+only return 1 when all checks passed.
+
+### Usage
+```
+npd validate [Options] <package> [<packages>...]
+```
+
+### Options
+|name, shorthand    |Description                     |
+|-------------------|--------------------------------|
+|--verbose, -v      |Show more detailed output       |
+
+### Examples
+
+validate single package
+```
+$ pip install napari-svg
+$ npd validate napari-svg
+----------------------------------------------------------------
+Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
+----------------------------------------------------------------
+Validating package napari-svg
+* Classifier check: FAILED
+* Entrypoint check - syntax: PASSED
+* Entrypoint check - plugin registration: PASSED
+* Entrypoint check - registered modules exist: PASSED
+* Hooks registration check - svg: PASSED
+----------------------------------------------------------------
+Error: 'Framework :: napari' does not exist for napari-svg's 12 known classifier(s)
+----------------------------------------------------------------
+```
+
+validate multiple packages with verbose output:
+```
+$ pip install napari-svg
+$ pip install napari-demo
+$ npd validate napari-svg napari-demo -v
+----------------------------------------------------------------
+Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
+----------------------------------------------------------------
+Validating package napari-svg
+* Classifier check: FAILED
+* Entrypoint check - syntax: PASSED
+* Entrypoint check - plugin registration: PASSED
+        Plugins registerd under napari-svg: ['svg']
+* Entrypoint check - registered modules exist: PASSED
+        Modules found: ['napari_svg']
+* Hooks registration check - svg: PASSED
+        Found 6 registered writer hook(s) for svg:
+        - napari_get_writer
+        - napari_write_image
+        - napari_write_labels
+        - napari_write_points
+        - napari_write_shapes
+        - napari_write_vectors
+----------------------------------------------------------------
+Validating package napari-demo
+* Classifier check: PASSED
+* Entrypoint check - syntax: PASSED
+* Entrypoint check - plugin registration: PASSED
+        Plugins registerd under napari-demo: ['napari-demo', 'napari-else']
+* Entrypoint check - registered modules exist: PASSED
+        Modules found: ['napari_demo', 'napari_else']
+* Hooks registration check - napari-demo: PASSED
+        Found 1 registered function hook(s) for napari-demo:
+        - image arithmetic
+* Hooks registration check - napari-else: PASSED
+        Found 1 registered function hook(s) for napari-else:
+        - image arithmetic other
+----------------------------------------------------------------
+Error: 'Framework :: napari' does not exist for napari-svg's 12 known classifier(s): ['Development Status :: 4 - Beta', 'Intended Audience :: Developers', 'Topic :: Software Development :: Testing', 'Programming Language :: Python', 'Programming Language :: Python :: 3', 'Programming Language :: Python :: 3.6', 'Programming Language :: Python :: 3.7', 'Programming Language :: Python :: 3.8', 'Programming Language :: Python :: Implementation :: CPython', 'Programming Language :: Python :: Implementation :: PyPy', 'Operating System :: OS Independent', 'License :: OSI Approved :: BSD License']
+----------------------------------------------------------------
+```
+
+validate package with some errors:
+```
+$ pip install napari-demo
+$ npd validate napari-demo
+----------------------------------------------------------------
+Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
+----------------------------------------------------------------
+Validating package napari-demo
+* Classifier check: FAILED
+* Entrypoint check - syntax: PASSED
+* Entrypoint check - plugin registration: PASSED
+* Entrypoint check - registered modules exist: FAILED
+* Hooks registration check - napari-demo: PASSED
+* Hooks registration check - napari-else: FAILED
+----------------------------------------------------------------
+Error: 'Framework :: napari' does not exist for napari-demo's 10 known classifier(s)
+----------------------------------------------------------------
+Error: Did not find module napari_not_exists for plugin napari-else under package napari-demo
+----------------------------------------------------------------
+Error: No hook registered under plugin napari-else, Please see tutorial in https://napari.org/docs/dev/plugins/ to verify your plugin setup
+----------------------------------------------------------------
+```
+
+early termination of checks due to package having invalid entrypoint:
+```
+$ pip install napari-demo
+$ npd validate napari-demo
+----------------------------------------------------------------
+Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
+----------------------------------------------------------------
+Validating package napari-demo
+* Classifier check: PASSED
+* Entrypoint check - syntax: FAILED
+----------------------------------------------------------------
+Error: 'Framework :: napari' does not exist for napari-demo's 10 known classifier(s)
+----------------------------------------------------------------
+Error: Invalid entrypoint for package napari-demo, add 'napari.plugin' to the entrypoint under napari-demo
+----------------------------------------------------------------
+```
+```
+$ pip install napari-demo
+$ npd validate napari-demo
+----------------------------------------------------------------
+Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
+----------------------------------------------------------------
+Validating package napari-demo
+* Classifier check: PASSED
+* Entrypoint check - syntax: PASSED
+* Entrypoint check - plugin registration: FAILED
+* Entrypoint check - registered modules exist: FAILED
+----------------------------------------------------------------
+Error: No plugin registered for napari-demo, add plugin module registration under 'napari.plugin'
+----------------------------------------------------------------
+```
+
+---
+## npd discover
+
+### Description
+Discover plugins in current python environment, and show hook types for each plugin
+
+### Usage
+```
+$ npd discover
+```
+
+### Examples
+List plugins under current python environment:
+```
+$ pip install napari-demo
+$ pip install napari-svg
+$ pip install napari-hdf5-labels-io
+$ npd discover
+----------------------------------------------------------------
+Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
+----------------------------------------------------------------
+Found 1 registered function hook(s) for napari-demo:
+- image arithmetic
+----------------------------------------------------------------
+Found 6 registered writer hook(s) for svg:
+- napari_get_writer
+- napari_write_image
+- napari_write_labels
+- napari_write_points
+- napari_write_shapes
+- napari_write_vectors
+----------------------------------------------------------------
+Found 1 registered function hook(s) for napari-else:
+- image arithmetic other
+----------------------------------------------------------------
+Found 1 registered reader hook(s) for napari-hdf5-labels-io:
+- napari_get_reader
+Found 1 registered writer hook(s) for napari-hdf5-labels-io:
+- napari_get_writer
+----------------------------------------------------------------
+
+```

--- a/documentation/CLI_usage.md
+++ b/documentation/CLI_usage.md
@@ -40,8 +40,8 @@ npd validate [Options] <package>
 
 validate without verbose flag
 ```
-$ pip install napari-svg
-$ npd validate napari-svg
+$ pip install -e .
+$ npd validate napari-demo
 ----------------------------------------------------------------
 Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
 ----------------------------------------------------------------
@@ -52,14 +52,14 @@ Validating package napari-svg
 * Entrypoint check - registered modules exist: PASSED
 * Hooks registration check - svg: PASSED
 ----------------------------------------------------------------
-Error: 'Framework :: napari' does not exist for napari-svg's 12 known classifier(s), add 'Framework :: napari' to 
+Error: 'Framework :: napari' does not exist for napari-demo's 12 known classifier(s), add 'Framework :: napari' to 
 classifier list, see https://napari.org/docs/dev/plugins/for_plugin_developers.html#step-4-share-your-plugin-with-the-world
 ----------------------------------------------------------------
 ```
 
 validate package with some errors and verbose flag:
 ```
-$ pip install napari-demo
+$ pip install -e .
 $ npd validate napari-demo
 ----------------------------------------------------------------
 Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
@@ -87,7 +87,7 @@ Error: No hook registered under plugin napari-else, Please see tutorial in https
 
 early termination of checks due to package having invalid entrypoint:
 ```
-$ pip install napari-demo
+$ pip install -e .
 $ npd validate napari-demo
 ----------------------------------------------------------------
 Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
@@ -98,11 +98,13 @@ Validating package napari-demo
 ----------------------------------------------------------------
 Error: 'Framework :: napari' does not exist for napari-demo's 10 known classifier(s)
 ----------------------------------------------------------------
-Error: Invalid entrypoint for package napari-demo, add 'napari.plugin' to the entrypoint under napari-demo
+Error: Invalid entrypoint for package napari-demo, add 'napari.plugin' section to the entrypoint under napari-demo, see https://napari.org/docs/dev/plugins/for_plugin_developers.html#step-3-make-your-plugin-discoverable
 ----------------------------------------------------------------
 ```
+
+early termination of checks due to no plugin registered for package:
 ```
-$ pip install napari-demo
+$ pip install -e .
 $ npd validate napari-demo
 ----------------------------------------------------------------
 Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
@@ -113,7 +115,7 @@ Validating package napari-demo
 * Entrypoint check - plugin registration: FAILED
 * Entrypoint check - registered modules exist: FAILED
 ----------------------------------------------------------------
-Error: No plugin registered for napari-demo, add plugin module registration under 'napari.plugin'
+Error: No plugin registered for napari-demo, add plugin module registration under 'napari.plugin', see https://napari.org/docs/dev/plugins/for_plugin_developers.html#step-3-make-your-plugin-discoverable
 ----------------------------------------------------------------
 ```
 

--- a/documentation/CLI_usage.md
+++ b/documentation/CLI_usage.md
@@ -5,6 +5,8 @@
 
 ### Description
 napari plugin devtools scans the current python environment to find out details about napari plugin information.
+To validate a local folder with plugin code, for example a plugin that is working in progress, first install it,
+for example `pip install -e .` and then run npd in the same environment.
 
 ### Usage
 ```
@@ -26,7 +28,7 @@ only return 1 when all checks passed.
 
 ### Usage
 ```
-npd validate [Options] <package> [<packages>...]
+npd validate [Options] <package>
 ```
 
 ### Options
@@ -36,7 +38,7 @@ npd validate [Options] <package> [<packages>...]
 
 ### Examples
 
-validate single package
+validate without verbose flag
 ```
 $ pip install napari-svg
 $ npd validate napari-svg
@@ -50,53 +52,12 @@ Validating package napari-svg
 * Entrypoint check - registered modules exist: PASSED
 * Hooks registration check - svg: PASSED
 ----------------------------------------------------------------
-Error: 'Framework :: napari' does not exist for napari-svg's 12 known classifier(s)
+Error: 'Framework :: napari' does not exist for napari-svg's 12 known classifier(s), add 'Framework :: napari' to 
+classifier list, see https://napari.org/docs/dev/plugins/for_plugin_developers.html#step-4-share-your-plugin-with-the-world
 ----------------------------------------------------------------
 ```
 
-validate multiple packages with verbose output:
-```
-$ pip install napari-svg
-$ pip install napari-demo
-$ npd validate napari-svg napari-demo -v
-----------------------------------------------------------------
-Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
-----------------------------------------------------------------
-Validating package napari-svg
-* Classifier check: FAILED
-* Entrypoint check - syntax: PASSED
-* Entrypoint check - plugin registration: PASSED
-        Plugins registerd under napari-svg: ['svg']
-* Entrypoint check - registered modules exist: PASSED
-        Modules found: ['napari_svg']
-* Hooks registration check - svg: PASSED
-        Found 6 registered writer hook(s) for svg:
-        - napari_get_writer
-        - napari_write_image
-        - napari_write_labels
-        - napari_write_points
-        - napari_write_shapes
-        - napari_write_vectors
-----------------------------------------------------------------
-Validating package napari-demo
-* Classifier check: PASSED
-* Entrypoint check - syntax: PASSED
-* Entrypoint check - plugin registration: PASSED
-        Plugins registerd under napari-demo: ['napari-demo', 'napari-else']
-* Entrypoint check - registered modules exist: PASSED
-        Modules found: ['napari_demo', 'napari_else']
-* Hooks registration check - napari-demo: PASSED
-        Found 1 registered function hook(s) for napari-demo:
-        - image arithmetic
-* Hooks registration check - napari-else: PASSED
-        Found 1 registered function hook(s) for napari-else:
-        - image arithmetic other
-----------------------------------------------------------------
-Error: 'Framework :: napari' does not exist for napari-svg's 12 known classifier(s): ['Development Status :: 4 - Beta', 'Intended Audience :: Developers', 'Topic :: Software Development :: Testing', 'Programming Language :: Python', 'Programming Language :: Python :: 3', 'Programming Language :: Python :: 3.6', 'Programming Language :: Python :: 3.7', 'Programming Language :: Python :: 3.8', 'Programming Language :: Python :: Implementation :: CPython', 'Programming Language :: Python :: Implementation :: PyPy', 'Operating System :: OS Independent', 'License :: OSI Approved :: BSD License']
-----------------------------------------------------------------
-```
-
-validate package with some errors:
+validate package with some errors and verbose flag:
 ```
 $ pip install napari-demo
 $ npd validate napari-demo
@@ -111,7 +72,12 @@ Validating package napari-demo
 * Hooks registration check - napari-demo: PASSED
 * Hooks registration check - napari-else: FAILED
 ----------------------------------------------------------------
-Error: 'Framework :: napari' does not exist for napari-demo's 10 known classifier(s)
+verbose output
+Plugins registerd under napari-demo: ['napari-demo', 'napari-else']
+Found 1 registered function hook(s) for napari-demo
+- image arithmetic
+----------------------------------------------------------------
+Error: 'Framework :: napari' does not exist for napari-demo's 10 known classifier(s), add 'Framework :: napari' to classifier list, see https://napari.org/docs/dev/plugins/for_plugin_developers.html#step-4-share-your-plugin-with-the-world
 ----------------------------------------------------------------
 Error: Did not find module napari_not_exists for plugin napari-else under package napari-demo
 ----------------------------------------------------------------
@@ -159,8 +125,14 @@ Discover plugins in current python environment, and show hook types for each plu
 
 ### Usage
 ```
-$ npd discover
+$ npd discover [Options]
 ```
+
+### Options
+|name, shorthand    |Description                     |
+|-------------------|--------------------------------|
+|--verbose, -v      |Show more detailed output       |
+
 
 ### Examples
 List plugins under current python environment:
@@ -168,28 +140,42 @@ List plugins under current python environment:
 $ pip install napari-demo
 $ pip install napari-svg
 $ pip install napari-hdf5-labels-io
-$ npd discover
+$ npd discover            
 ----------------------------------------------------------------
 Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
 ----------------------------------------------------------------
-Found 1 registered function hook(s) for napari-demo:
-- image arithmetic
+Plugin found: svg
+Plugin found: napari-demo
+Plugin found: napari-hdf5-labels-io
+
+To see registered hooks, enable verbose flag -v
+```
+
+List plugins under current python environment with verbose flag:
+```
+$ pip install napari-demo
+$ pip install napari-svg
+$ pip install napari-hdf5-labels-io
+$ npd discover -v         
 ----------------------------------------------------------------
-Found 6 registered writer hook(s) for svg:
+Scanning current python environment: /Library/Frameworks/Python.framework/Versions/3.8
+----------------------------------------------------------------
+Plugin found: napari-hdf5-labels-io
+Plugin found: svg
+Plugin found: napari-demo
+----------------------------------------------------------------
+verbose output
+Found 1 registered reader hook(s) for napari-hdf5-labels-io
+- napari_get_reader
+Found 1 registered writer hook(s) for napari-hdf5-labels-io
+- napari_get_writer
+Found 6 registered writer hook(s) for svg
 - napari_get_writer
 - napari_write_image
 - napari_write_labels
 - napari_write_points
 - napari_write_shapes
 - napari_write_vectors
-----------------------------------------------------------------
-Found 1 registered function hook(s) for napari-else:
-- image arithmetic other
-----------------------------------------------------------------
-Found 1 registered reader hook(s) for napari-hdf5-labels-io:
-- napari_get_reader
-Found 1 registered writer hook(s) for napari-hdf5-labels-io:
-- napari_get_writer
-----------------------------------------------------------------
-
+Found 1 registered function hook(s) for napari-demo
+- image arithmetic
 ```

--- a/documentation/CLI_usage.md
+++ b/documentation/CLI_usage.md
@@ -24,7 +24,7 @@ npd [COMMANDS] [ARGS...]
 
 ### Description
 Validate package(s) within current python environment, report PASSED or FAILED for each check, 
-only return 1 when all checks passed.
+only exit with code 0 when all checks passed.
 
 ### Usage
 ```
@@ -38,7 +38,7 @@ npd validate [Options] <package>
 
 ### Examples
 
-validate without verbose flag
+validate a local package named napari-demo without verbose flag
 ```
 $ pip install -e .
 $ npd validate napari-demo
@@ -57,7 +57,7 @@ classifier list, see https://napari.org/docs/dev/plugins/for_plugin_developers.h
 ----------------------------------------------------------------
 ```
 
-validate package with some errors and verbose flag:
+validate a local package named napari-demo with some errors and verbose flag:
 ```
 $ pip install -e .
 $ npd validate napari-demo
@@ -123,7 +123,7 @@ Error: No plugin registered for napari-demo, add plugin module registration unde
 ## npd discover
 
 ### Description
-Discover plugins in current python environment, and show hook types for each plugin
+Discover plugins in current python environment, and show hook types for each plugin in verbose mode
 
 ### Usage
 ```

--- a/napari_plugin_devtools/__init__.py
+++ b/napari_plugin_devtools/__init__.py
@@ -1,11 +1,6 @@
 __all__ = [
-    "validate_package",
     "validate_function",
     "list_hook_implementations",
 ]
 
-from .validation import (
-    list_hook_implementations,
-    validate_function,
-    validate_package,
-)
+from .validation import list_hook_implementations, validate_function

--- a/napari_plugin_devtools/__main__.py
+++ b/napari_plugin_devtools/__main__.py
@@ -131,7 +131,7 @@ def validate_entries(args):
                     spec = importlib.find_spec(module)
                     if spec is None:
                         print(
-                            f"Specified module {module} is not found under {plugin}"
+                            f"Specified module {module} is not found for {plugin}"
                         )
                         entry_error = True
                     else:
@@ -223,12 +223,12 @@ def validate_hooks(plugins, verbose):
 
     for plugin in plugins:
         if plugin not in plugin_functions:
-            if '' in errors:
-                errors[''].append(
+            if plugin in errors:
+                errors[plugin].append(
                     f"Error! No hook found in current environment for plugin: {plugin}."
                 )
             else:
-                errors[''] = [
+                errors[plugin] = [
                     f"Error! No hook found in current environment for plugin: {plugin}."
                 ]
             print_tutorial = True

--- a/napari_plugin_devtools/__main__.py
+++ b/napari_plugin_devtools/__main__.py
@@ -2,25 +2,34 @@
 napari plugin command line developer tool.
 """
 import argparse
-import json
+import importlib.util as importlib
 import os
 import sys
+
+from pkg_resources import DistributionNotFound, get_entry_map
 
 from .validation import Options, list_hook_implementations, validate_package
 
 
 def main():
     parser = argparse.ArgumentParser()
-    sub_parsers = parser.add_subparsers(help='validate plugins')
+    sub_parsers = parser.add_subparsers(
+        help='npd validate scans your current python environment to validate '
+        'hook registration and entrypoint information, also looks for '
+        'built artifacts under dist folder to validate classifiers.'
+    )
     validate_parser = sub_parsers.add_parser("validate")
     validate_parser.add_argument(
-        "-i",
-        "--include-plugin",
+        'plugins',
         nargs="+",
-        help="only include specified plugins",
+        help="plugin(s) to validate",
     )
     validate_parser.add_argument(
-        "-e", "--exclude-plugin", nargs="+", help="exclude specified plugins"
+        "-d",
+        "--dist",
+        help="name of the dist, default to first plugin name if not provided, "
+        "specify when there are multiple plugins in same package or "
+        "plugin is different from package name",
     )
     validate_parser.add_argument(
         "-v", "--verbose", action="store_true", help="print verbose report"
@@ -29,53 +38,205 @@ def main():
         parser.print_help()
         print("----Currently we only support 'npd validate'----")
         parser.exit()
+
     args = parser.parse_args()
 
-    hooks = ['reader', 'writer', 'function', 'widget']
-
+    if args.dist is None:
+        args.dist = args.plugins[0]
     error_code = 0
 
     print("-----------------------------------------------------------------")
-    hooks_validated = validate_hooks(
-        hooks, args.verbose, args.include_plugin, args.exclude_plugin
-    )
+    print("Hooks validation:")
+    hooks_error = validate_functions(args)
 
-    if hooks_validated:
-        print("Success! Validated Function Hooks.")
-    else:
-        error_code = 1
-        print("Error! No hook found in current environment.")
-        print("Please see tutorial in https://napari.org/docs/dev/plugins/")
+    print("-----------------------------------------------------------------")
+    print("Builds validation:")
+    package_error = validate_builds(args)
+
+    print("-----------------------------------------------------------------")
+    print("Entrypoint validation:")
+    entry_error = validate_entries(args)
+
     print("-----------------------------------------------------------------")
 
+    if hooks_error:
+        print("Hooks validation: FAILED")
+        error_code = 1
+    else:
+        print("Hooks validation: PASSED")
+
+    if package_error is None:
+        print("Builds validation: SKIPPED")
+    elif package_error:
+        print("Builds validation: FAILED")
+        error_code = 1
+    else:
+        print("Builds validation: PASSED")
+
+    if entry_error:
+        print("Entrypoint validation: FAILED")
+        error_code = 1
+    else:
+        print("Entrypoint validation: PASSED")
+    return error_code
+
+
+def validate_functions(args):
+    hooks_errors = validate_hooks(args.plugins, args.verbose)
+    hooks_error = False
+    if hooks_errors:
+        for key, value in hooks_errors.items():
+            if value:
+                hooks_error = True
+                print(f"Error[{key}]: {value}")
+    return hooks_error
+
+
+def validate_builds(args):
+    package_error = None
     if os.path.isdir("dist"):
         if not validate_packages("dist", args.verbose):
-            error_code = 1
+            package_error = True
             print("Error! Classifier is missing in at least 1 package.")
+        else:
+            package_error = False
     else:
         print("Skipped classifier validation, no package found. Skipping")
         print("this test may cause user not seeing your plugin in napari")
         print("plugin installation menu. To rerun, Repackage dist folder.")
-
-    print("-----------------------------------------------------------------")
-    return error_code
+    return package_error
 
 
-def validate_hooks(hooks, verbose, include_plugin, exclude_plugin):
-    errors = []
-    hooks_valid = True
-    for option in Options:
-        if option.name in hooks:
-            hook_found, hook_valid = validate_hook(
-                option, verbose, include_plugin, exclude_plugin
-            )
-            if not hook_found:
-                errors.append(option)
-                hooks_valid = hooks_valid and hook_valid
-    if len(errors) == len(Options):
-        hooks_valid = False
+def validate_entries(args):
+    entry_error = False
+    for plugin in args.plugins:
+        try:
+            dist = args.dist
+            entry_map = get_entry_map(dist)
 
-    return hooks_valid
+            if 'napari.plugin' not in entry_map:
+                print(f"Error: Invalid entrypoint for {plugin}")
+                print(f"Add 'napari.plugin' to the entrypoint under {plugin}")
+                entry_error = True
+            else:
+                module = entry_map['napari.plugin'][plugin].module_name
+                name = entry_map['napari.plugin'][plugin].name
+                if plugin != name:
+                    print(
+                        f"Plugin name not matching, expecting "
+                        f"{plugin}, but found {name}"
+                    )
+                    entry_error = True
+                else:
+                    spec = importlib.find_spec(module)
+                    if spec is None:
+                        print(
+                            f"Specified module {module} is not found under {plugin}"
+                        )
+                        entry_error = True
+                    else:
+                        print(
+                            f"Validated entrypoint {module} exists for {plugin}."
+                        )
+        except DistributionNotFound:
+            print(f"Error: Unable to retrive entrypoint for {plugin}.")
+            print(f"Check your entrypoint setup to verify {plugin} is added.")
+            entry_error = True
+
+    if entry_error:
+        print("After your made the proper fix, reinstall the package.")
+        print("(Not sure how? try 'pip install -e <plugin folder>')")
+    return entry_error
+
+
+def validate_hooks(plugins, verbose):
+    plugin_functions = dict()
+
+    signatures, errors = list_hook_implementations()
+    for (option, functions) in signatures.items():
+        for function_signature in functions:
+            name = function_signature['plugin name']
+            if name in plugins:
+                if (
+                    name in plugin_functions
+                    and option in plugin_functions[name]
+                ):
+                    plugin_functions[name][option].append(function_signature)
+                elif name in plugin_functions:
+                    plugin_functions[name][option] = [function_signature]
+                else:
+                    plugin_functions[name] = {option: [function_signature]}
+
+    if plugin_functions:
+        print("Plugin hook registration for current environment:")
+    for name, mapping in plugin_functions.items():
+        for option, signatures in mapping.items():
+            if option == Options.function or option == Options.widget:
+                print(
+                    f'Found {len(signatures)} registered '
+                    f'{option.name} hook(s) for {name}:'
+                )
+                if verbose:
+                    print(
+                        "-",
+                        "\n- ".join(
+                            str(signature) for signature in signatures
+                        ),
+                    )
+                else:
+                    print(
+                        "-",
+                        "\n- ".join(
+                            signature["function name"]
+                            for signature in signatures
+                        ),
+                    )
+            else:
+                print(
+                    f"Found {len(signatures)} registered "
+                    f"{option.name} hook(s) for {name}:"
+                )
+                if verbose:
+                    print(
+                        "-",
+                        "\n- ".join(
+                            str(signature) for signature in signatures
+                        ),
+                    )
+                else:
+                    print(
+                        "-",
+                        "\n- ".join(
+                            signature["spec"] for signature in signatures
+                        ),
+                    )
+        print()
+
+    print_tutorial = False
+
+    if len(plugin_functions) == 0:
+        if '' in errors:
+            errors[''].append("Error! No hook found in current environment.")
+        else:
+            errors[''] = ["Error! No hook found in current environment."]
+        print_tutorial = True
+
+    for plugin in plugins:
+        if plugin not in plugin_functions:
+            if '' in errors:
+                errors[''].append(
+                    f"Error! No hook found in current environment for plugin: {plugin}."
+                )
+            else:
+                errors[''] = [
+                    f"Error! No hook found in current environment for plugin: {plugin}."
+                ]
+            print_tutorial = True
+
+    if print_tutorial:
+        print("Please see tutorial in https://napari.org/docs/dev/plugins/")
+        print("to verify your plugin has the correct setup.")
+    return errors
 
 
 def validate_packages(folder, verbose):
@@ -87,26 +248,10 @@ def validate_packages(folder, verbose):
 
     for package in packages:
         package_validated = validate_package(package, verbose=verbose)
-        if package_validated and verbose:
+        if package_validated:
             print(f'validated {package}')
         packages_validated = packages_validated and package_validated
-    if packages_validated:
-        print(f"Success! All {len(packages)} package(s) are validated")
     return packages_validated
-
-
-def validate_hook(option, verbose, include_plugins, exclude_plugins):
-    validated, signatures = list_hook_implementations(
-        option, include_plugins, exclude_plugins
-    )
-    if len(signatures) == 0:
-        return False, validated
-    else:
-        print(f'Found {len(signatures)} {option.name} hook(s)')
-        if verbose:
-            signature = json.dumps(signatures, default=str, indent=4)
-            print(f'{option.name}: {signature}')
-        return True, validated
 
 
 if __name__ == '__main__':

--- a/napari_plugin_devtools/validation.py
+++ b/napari_plugin_devtools/validation.py
@@ -68,25 +68,24 @@ def validate_function(
 
     Returns
     ------
-    validated: boolean
-        True if the function is valid, False otherwise
+    errors: dict of str to str array
+        errors found when validating function.
     """
-    validated = True
+    errors = {}
     plugin_name = hookimpl.plugin_name
-    hook_name = '`napari_experimental_provide_function`'
     if plugin_name is None:
-        validated = False
-        print("Error: No plugin name specified")
-
+        errors[''] = ["Error: No plugin name specified"]
+    else:
+        errors[plugin_name] = []
     for func in args if isinstance(args, list) else [args]:
         if isinstance(func, tuple):
-            validated = False
-            print("Error: convert tuple to list for multiple callables")
+            errors[plugin_name].append(
+                "Error: convert tuple to list " "for multiple callables"
+            )
         elif not isinstance(func, FunctionType):
-            validated = False
-            print(
+            errors[plugin_name].append(
                 f'Error: Plugin {plugin_name!r} provided a non-callable type '
-                f'to {hook_name}: {type(func)!r}. Function ignored.'
+                f': {type(func)!r}. Function ignored.'
             )
 
         # Get function name
@@ -94,38 +93,31 @@ def validate_function(
 
         key = (plugin_name, name)
         if key in functions:
-            validated = False
-            print(
+            errors[plugin_name].append(
                 f"Error: Plugin '{plugin_name}' has already registered a "
                 f"function '{name}' which has now been overwritten"
             )
         functions[key] = func
 
-    return validated
+    return errors
 
 
-def list_hook_implementations(option, include_plugins, exclude_plugins):
+def list_hook_implementations():
     """
     List hook implementations found when loaded by napari
 
     Parameters
     ----------
-    option : Options
-        type of the function hook to check
-    include_plugins : set[str]
-        if provided, only show functions from the given plugin name
-    exclude_plugins : set[str]
-        if provided, do not show functions from the given set
 
     Returns
     -------
-    validated: boolean
-        True if the functions are validated, False otherwise
-    functions_signatures: List
-        list of function signatures
+    functions_signatures: dict of option to list
+        different types of list of function signatures
+    errors: dict of str to str array
+        errors found when validating function.
 
     Example:
-    [{
+    {Options.reader: {
         "plugin name": "napari-demo",
         "function name": "image arithmetic",
         "args": ["layerA", "operation", "layerB"],
@@ -136,29 +128,27 @@ def list_hook_implementations(option, include_plugins, exclude_plugins):
             "layerB": "napari.types.ImageData"
         },
         "defaults": null
-    }]
+    }}
     """
-    function_signatures = []
-    validated = True
-    functions = dict()
-    if exclude_plugins is None:
-        exclude_plugins = {'builtins', 'svg'}
-    else:
-        exclude_plugins.add('builtins')
-        exclude_plugins.add('svg')  # excluding default installed plugins
-    if option == Options.function or option == Options.widget:
-        fw_hook = option.value[0]
-        res = fw_hook._hookexec(fw_hook, fw_hook.get_hookimpls(), None)
-        for result, impl in zip(res.result, res.implementation):
-            validated = validated and validate_function(
-                result, impl, functions
-            )
-        for key, value in functions.items():
-            spec = inspect.getfullargspec(value)
-            if (key[0] not in exclude_plugins) and (
-                include_plugins is None or key[0] in include_plugins
-            ):
-                function_signatures.append(
+    function_signatures = {}
+    errors = {}
+    for option in Options:
+        functions = dict()
+        function_signatures[option] = []
+        if option == Options.function or option == Options.widget:
+            fw_hook = option.value[0]
+            res = fw_hook._hookexec(fw_hook, fw_hook.get_hookimpls(), None)
+            for result, impl in zip(res.result, res.implementation):
+                for plugin_name, error_messages in validate_function(
+                    result, impl, functions
+                ).items():
+                    if plugin_name in errors:
+                        errors[plugin_name].extend(error_messages)
+                    else:
+                        errors[plugin_name] = error_messages
+            for key, value in functions.items():
+                spec = inspect.getfullargspec(value)
+                function_signatures[option].append(
                     {
                         'plugin name': key[0],
                         'function name': key[1],
@@ -167,14 +157,11 @@ def list_hook_implementations(option, include_plugins, exclude_plugins):
                         'defaults': spec.defaults,
                     }
                 )
-    elif option == Options.reader or option == Options.writer:
-        for hook_spec in option.value:
-            for hook_impl in hook_spec.get_hookimpls():
-                if (hook_impl.plugin_name not in exclude_plugins) and (
-                    include_plugins is None
-                    or hook_impl.plugin_name in include_plugins
-                ):
-                    function_signatures.append(
+
+        elif option == Options.reader or option == Options.writer:
+            for hook_spec in option.value:
+                for hook_impl in hook_spec.get_hookimpls():
+                    function_signatures[option].append(
                         {
                             'plugin name': hook_impl.plugin_name,
                             'spec': hook_impl.specname,
@@ -182,4 +169,5 @@ def list_hook_implementations(option, include_plugins, exclude_plugins):
                             'trylast': hook_impl.trylast,
                         }
                     )
-    return validated, function_signatures
+
+    return function_signatures, errors

--- a/napari_plugin_devtools/validation.py
+++ b/napari_plugin_devtools/validation.py
@@ -5,7 +5,6 @@ from typing import Callable, Dict, List, Union
 
 from napari.plugins import plugin_manager
 from napari_plugin_engine import HookImplementation
-from pkginfo import SDist, Wheel
 
 
 class Options(enum.Enum):
@@ -23,31 +22,6 @@ class Options(enum.Enum):
     ]
     function = [plugin_manager.hook.napari_experimental_provide_function]
     widget = [plugin_manager.hook.napari_experimental_provide_dock_widget]
-
-
-def validate_package(pkgpath, verbose=False):
-    if pkgpath.endswith('.tar.gz'):
-        dist = SDist(pkgpath)
-    elif pkgpath.endswith('.whl'):
-        dist = Wheel(pkgpath)
-    else:
-        print(f'Error: Not a valid format {pkgpath}')
-        return False
-    if not (
-        hasattr(dist, 'classifiers')
-        and 'Framework :: napari' in dist.classifiers
-    ):
-        print(
-            f'Error: "Framework :: napari" was not found in {pkgpath}\n'
-            f'Please update your package setup configuration to include '
-            f'"Framework :: napari", then rebuild the distribution.'
-        )
-        if verbose:
-            classifiers = '\n\t'.join(dist.classifiers)
-            print(f'Know classifiers:\n\t{classifiers}\n')
-        return False
-    else:
-        return True
 
 
 def validate_function(

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     importlib-metadata>=1.5.0
     napari>=0.4.4
     pkginfo
+    termcolor
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Updated UI for the CLI to be more usable.
1. splited validation result to different sections where the errors are at the end, and individual PASS/FAIL check at the beginning
2. updated syntax to `npd validate <package name>` to run on a specific package
3. separated out modules to npd validate and npd discover for different functionality
4. added coloring of the result rendering
5. included a CLI_usage.md to demonstrate usages

see example below to get more intuitive idea of what it looks like now:

<img width="799" alt="Screen Shot 2021-03-30 at 12 46 57 PM" src="https://user-images.githubusercontent.com/41968256/113047346-0ca09e80-9156-11eb-876a-aa6702363afa.png">


npd discover (without and with verbose flag)
<img width="660" alt="Screen Shot 2021-03-30 at 12 17 05 PM" src="https://user-images.githubusercontent.com/41968256/113047164-d400c500-9155-11eb-84f6-46b07735a98a.png">
